### PR TITLE
Fix parameter_override and start() remotely bugs

### DIFF
--- a/pipeline_from_tasks.py
+++ b/pipeline_from_tasks.py
@@ -28,10 +28,11 @@ def run_pipeline():
         name="Pipeline demo", project="examples", version="0.0.1", add_pipeline_tags=False
     )
 
-    # pipe.add_parameter(
-    #     "url",
-    #     "dataset_url",
-    # )
+    pipe.add_parameter(
+        "url",
+        "https://github.com/allegroai/events/raw/master/odsc20-east/generic/iris_dataset.pkl",
+        "dataset_url",
+    )
 
     pipe.set_default_execution_queue("pipeline")
 
@@ -66,6 +67,6 @@ def run_pipeline():
     pipe.start_locally()
 
     # Starting the pipeline (in the background)
-    # pipe.start(queue="pipeline")  # already set pipeline queue
+    # pipe.start(queue="use_diffent_queue_name_for_pipeline_itself")
 
     print("done")


### PR DESCRIPTION
Hi I found some bugs when running the pipeline:
1. In the `parameter_override` argument for `stage_data`, there's no `pipeline.url` to set, so I uncommented the above `pipe.add_parameter` code and add a default `dataset_url`. Additionally, the `dataset_url` text should not be in the 2nd position of `pipe.add_parameter` as it's for the `default` value, according to [pipelinecontroller docs](https://clear.ml/docs/latest/docs/references/sdk/automation_controller_pipelinecontroller#add_parameter)
2. We can not use the same queue for both pipeline and its tasks as it will make the pipeline stuck, so just use different name for the pipeline queue. You can check this [GitHub issue](https://github.com/clearml/clearml/issues/1328) for this problem